### PR TITLE
Add single-page web app with world map and user location pin

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -17,7 +17,7 @@
     <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
     <script>
         // Initialize the map
-        var map = L.map('map').setView([20, 0], 2); // Centered at the world level
+        var map = L.map('map').setView([20, 0], 2); // World view
 
         // Add OpenStreetMap tiles
         L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
@@ -25,23 +25,18 @@
             attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
         }).addTo(map);
 
-        // Use the Geolocation API to get the user's current location
+        // Get the user's location
         if (navigator.geolocation) {
             navigator.geolocation.getCurrentPosition(function(position) {
                 var lat = position.coords.latitude;
                 var lon = position.coords.longitude;
-                
-                // Add a marker at the user's location
-                L.marker([lat, lon]).addTo(map)
-                    .bindPopup('You are here!').openPopup();
-
-                // Center the map on the user's location
-                map.setView([lat, lon], 4);
+                var marker = L.marker([lat, lon]).addTo(map);
+                map.setView([lat, lon], 4); // Zoom to user's location
             }, function() {
                 alert('Unable to retrieve your location');
             });
         } else {
-            alert('Geolocation is not supported by your browser');
+            alert('Geolocation is not supported by this browser.');
         }
     </script>
 </body>


### PR DESCRIPTION
This PR implements a single-page web application that displays a world map using Leaflet.js. It shows a pin at the visitor's current location using the Geolocation API. The map is initialized at a world zoom level and adjusts to the user's location once obtained.

Closes #8